### PR TITLE
Editorial: Reinstate async-evaluating state, with AsyncEvaluation as counter and initial state

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1016,6 +1016,117 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </tbody>
       </table>
     </emu-table>
+
+    <p><ins>
+      Alternatively, Let's consider a failure case, where _C_ fails execution andd returns an error.  When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propogate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
+    </ins></p>
+
+    <emu-table id="table-module-graph-cycle-async-fields-7" caption="Module fields after module _C_ finishes with an error">
+      <table>
+        <thead>
+          <tr>
+            <th>Module</th>
+            <th>[[DFSIndex]]</th>
+            <th>[[DFSAncestorIndex]]</th>
+            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncParentModules]]</th>
+            <th>[[PendingAsyncDependencies]]</th>
+            <th>[[EvaluationError]]</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>_A_</th>
+            <td>0</td>
+            <td>0</td>
+            <td>*true*</td>
+            <td>&laquo; &raquo;</td>
+            <td>1 (_B_)</td>
+            <td>~empty~</td>
+          </tr>
+          <tr>
+            <th>_C_</th>
+            <td>2</td>
+            <td>1</td>
+            <td>*false*</td>
+            <td>&laquo; _A_ &raquo;</td>
+            <td>_C_'s evaluation error</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+
+    <p><ins>
+      _A_ will be rejected with the same error as _C_, as _C_ will call AsynModuleExecutionRejected on _A_, with _C_'s error. _A_.[[AsyncEvaluating]] is set to *false*.  At this point, the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is rejected. The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-8"></emu-xref>.
+    </ins></p>
+
+    <emu-table id="table-module-graph-cycle-async-fields-8" caption="Module fields after module _A_ is rejected">
+      <table>
+        <thead>
+          <tr>
+            <th>Module</th>
+            <th>[[DFSIndex]]</th>
+            <th>[[DFSAncestorIndex]]</th>
+            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncParentModules]]</th>
+            <th>[[PendingAsyncDependencies]]</th>
+            <th>[[EvaluationError]]</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>_A_</th>
+            <td>0</td>
+            <td>0</td>
+            <td>*false*</td>
+            <td>&laquo; &raquo;</td>
+            <td>0</td>
+            <td>_C_'s Evaluation Error</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+
+    <p><ins>
+      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*.  However, _A_ has already been rejected, so it will not be executed, and the sortedExecList will be empty, and AsyncModuleExecutionFulfilled will return. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
+    </ins></p>
+
+    <emu-table id="table-module-graph-cycle-async-fields-5" caption="Module fields after module _B_ finishes executing in an erroring graph">
+      <table>
+        <thead>
+          <tr>
+            <th>Module</th>
+            <th>[[DFSIndex]]</th>
+            <th>[[DFSAncestorIndex]]</th>
+            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncParentModules]]</th>
+            <th>[[PendingAsyncDependencies]]</th>
+            <th>[[EvaluationError]]</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>_A_</th>
+            <td>0</td>
+            <td>0</td>
+            <td>*false*</td>
+            <td>&laquo; &raquo;</td>
+            <td>0</td>
+            <td>_C_'s Evaluation Error</td>
+          </tr>
+          <tr>
+            <th>_B_</th>
+            <td>1</td>
+            <td>0</td>
+            <td>*false*</td>
+            <td>&laquo; _A_ &raquo;</td>
+            <td>0</td>
+            <td>~empty~</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+
   </emu-clause>
 </emu-clause>
 <emu-clause id="sec-source-text-module-records">

--- a/spec.html
+++ b/spec.html
@@ -1018,7 +1018,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-table>
 
     <p><ins>
-      Alternatively, Let's consider a failure case, where _C_ fails execution andd returns an error.  When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propogate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
+      Alternatively, consider a failure case where _C_ fails execution and returns an error.  When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propagate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-7" caption="Module fields after module _C_ finishes with an error">
@@ -1057,7 +1057,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-table>
 
     <p><ins>
-      _A_ will be rejected with the same error as _C_, as _C_ will call AsynModuleExecutionRejected on _A_, with _C_'s error. _A_.[[AsyncEvaluating]] is set to *false*.  At this point, the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is rejected. The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-8"></emu-xref>.
+      _A_ will be rejected with the same error as _C_ since _C_ will call AsyncModuleExecutionRejected on _A_ with _C_'s error. _A_.[[AsyncEvaluating]] is set to *false*.  At this point the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is rejected. The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-8"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-8" caption="Module fields after module _A_ is rejected">
@@ -1088,7 +1088,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-table>
 
     <p><ins>
-      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*.  However, _A_ has already been rejected, so it will not be executed, and the sortedExecList will be empty, and AsyncModuleExecutionFulfilled will return. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
+      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*. GatherAsyncParentCompletions is called on _B_. However, _A_.[[CycleRoot]] is _A_ which has an evaluation error, so it will not be added to the returned _sortedExecList_ and AsyncModuleExecutionFulfilled will return without further processing. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-5" caption="Module fields after module _B_ finishes executing in an erroring graph">

--- a/spec.html
+++ b/spec.html
@@ -1018,7 +1018,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-table>
 
     <p><ins>
-      Alternatively, consider a failure case where _C_ fails execution and returns an error.  When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propagate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
+      Alternatively, consider a failure case where _C_ fails execution and returns an error before _B_ has finished executing. When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propagate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-7" caption="Module fields after module _C_ finishes with an error">
@@ -1088,7 +1088,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-table>
 
     <p><ins>
-      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*. GatherAsyncParentCompletions is called on _B_. However, _A_.[[CycleRoot]] is _A_ which has an evaluation error, so it will not be added to the returned _sortedExecList_ and AsyncModuleExecutionFulfilled will return without further processing. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
+      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*.  GatherAsyncParentCompletions is called on _B_. However, _A_.[[CycleRoot]] is _A_ which has an evaluation error, so it will not be added to the returned _sortedExecList_ and AsyncModuleExecutionFulfilled will return without further processing. Any future importer of _B_ will resolve the rejection of _B_.[[CycleRoot]].[[EvaluationError]] from the evaluation error from _C_ that was set on the cycle root _A_. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-5" caption="Module fields after module _B_ finishes executing in an erroring graph">


### PR DESCRIPTION
This brings back an `~async-evaluating~` `[[State]]` value which is set for any module either currently asynchronously executing, or waiting on a dependency that is currently asynchronously executing. The previous issue with this state was that we still needed a separate field for `AsyncEvaluating` due to handling cycle transitions, as discussed in https://github.com/tc39/proposal-top-level-await/pull/114.

We can bring this state back by adopting the state as well as still using the separate field for `AsyncEvaluating` which is renamed to `AsyncEvaluation`. Instead of treating execution completion as the transition of `AsyncEvaluating` to false as before, we then treat execution completion as the transition of the `async-evaluating` state to `evaluated`.

This PR can be seen as performing the following (non-normative) replacement operations in order:
* Replace all `~evaluated~` state checks with a check for `~evaluated~` or `~evaluating-async~`.
* Replace the `~evaluating~ -> ~evaluated~` transition for async executions with an `~evaluating~ -> ~evaluating-async~` transition.
* Rename `[[AsyncEvaluating]]` to `[[QueuedEvaluation]]` with an initial `~empty~` state.
* Append a transition of `[[State]]` from `evaluating-async -> evaluating` at all sites where we previously set `[[AsyncEvaluating]]` to false.
* Never transition `[[QueuedEvaluation]]` back to false, and instead entirely use the `[[State]] == ~evaluated~` transitions for these checks.

The `AsyncEvaluation` field provides three purposes:

1. It indicates which modules have async dependencies.
2. It acts as the counter for async execution ordering.
3. Most importantly, during the initial execution traversal, it allows cycles to attach to the completion of other modules in the cycle by knowing that they are currently executing. Because cycles transition their states together from `~evaluating~` to `~async-evaluating~`, we wouldn't otherwise have this information for same within-cycle modules without some other indicator of a module of the same cycle that we need to attach to for async completion (we know it's evaluating because the "evaluating" state is set early in traversal, but the question is if its evaluating and its execution has already been triggered, which otherwise doesn't have a state representation). This was the underlying cause of previous bugs like https://github.com/tc39/proposal-top-level-await/pull/109.